### PR TITLE
[Enhancement] Adding an identifier, based on the first sequence number s...

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Please review the:
 	- frto_counter: A counter to track the Forward RTO-Recovery algorithm as described in RFC 4138
 	- rqueue: The number of bytes currently waiting to be read in the socket buffer a.ka. recvq
 	- wqueue: The number of bytes currently waiting to be sent in the socket buffer a.k.a. sendq
+	- socket_idf: The first sequence number seen for the connection to identify it. It can be used to detect that the connection has been reset and avoid reporting incorrect throughput. 
 
 - More sampling options added by Lyatiss, Inc.
 	- There are two options
@@ -54,12 +55,12 @@ This repository contains:
 
 		ubuntu@host:/usr/src$ sudo dkms add tcp_probe_plus
 	
-		Creating symlink /var/lib/dkms/tcp_probe_plus/1.1.5/source ->
-        	         /usr/src/tcp_probe_plus-1.1.5
+		Creating symlink /var/lib/dkms/tcp_probe_plus/1.1.6/source ->
+        	         /usr/src/tcp_probe_plus-1.1.6
 
 		DKMS: add completed.
-		ubuntu@host:/usr/src$ sudo dkms build tcp_probe_plus/1.1.5
-		ubuntu@host:/usr/src$ sudo dkms install tcp_probe_plus/1.1.5
+		ubuntu@host:/usr/src$ sudo dkms build tcp_probe_plus/1.1.6
+		ubuntu@host:/usr/src$ sudo dkms install tcp_probe_plus/1.1.6
 
 	Or from the kernel source
 
@@ -84,7 +85,7 @@ This repository contains:
  
 	ubuntu@host:~$ sudo modprobe tcp_probe_plus
 	ubuntu@host:~$ sudo cat /proc/net/tcpprobe
-	2.178670575 10.160.229.127:22 10.2.146.10:65221 80 0x3d58a46e 0x3d58a46e 6 2147483647 524280 43 53 255 0 0 0 0 0 0
+	2.178670575 10.160.229.127:22 10.2.146.10:65221 80 0x3d58a46e 0x3d58a46e 6 2147483647 524280 43 53 255 0 0 0 0 0 0 0x3d58a44e
 	...
 
 ## Exported Data
@@ -92,7 +93,7 @@ This repository contains:
 The data collected by the LKM is exported through `/proc/net/tcpprobe` and is formatted using the following code:
 
  	return scnprintf(tbuf, n,
-	 "%lu.%09lu %pI4:%u %pI4:%u %d %#llx %#x %u %u %u %u %u %u %u %u %u %u %u %u\n",
+	 "%lu.%09lu %pI4:%u %pI4:%u %d %#llx %#x %u %u %u %u %u %u %u %u %u %u %u %u %#llx\n",
 	 (unsigned long) tv.tv_sec,
 	 (unsigned long) tv.tv_nsec,
 	 &p->saddr, ntohs(p->sport),
@@ -100,7 +101,7 @@ The data collected by the LKM is exported through `/proc/net/tcpprobe` and is fo
 	 p->length, p->snd_nxt, p->snd_una,
 	 p->snd_cwnd, p->ssthresh, p->snd_wnd, p->srtt,
 	 p->rttvar, p->rto, p->lost, p->retrans, p->inflight, p->frto_counter,
-	 p->rqueue, p->wqueue);
+	 p->rqueue, p->wqueue, p->socket_idf);
 
 | Field | Description |
 | ----- | ------------|
@@ -125,6 +126,7 @@ The data collected by the LKM is exported through `/proc/net/tcpprobe` and is fo
 | frto_counter | Number of spurious RTO events |
 | rqueue | Number of bytes in the socket read queue |
 | wqueue | Number of bytes in the socket write queue |
+| socket_idf | First sequence number seen for the connection |  
  
 ## Sysctl interface
 


### PR DESCRIPTION
...een for a connection, to the list of metrics sent with each sample
- This allows to detect cases where the connection terminaison has not been detected and could cause erroneous computation of the throughput.
